### PR TITLE
Add original error info when throwing generation errors

### DIFF
--- a/packages/server/src/actions/form-assistant.tsx
+++ b/packages/server/src/actions/form-assistant.tsx
@@ -126,6 +126,6 @@ export async function generateGPTFormAutofill(args: AssistantArgsType) {
   try {
     return await customGenerateGPTFormAutofill(args, {});
   } catch (e) {
-    throw new Error('Failed to communicate with OpenAI. Please try again.');
+    throw new Error('Failed to communicate with OpenAI.', { cause: e });
   }
 }

--- a/packages/server/src/actions/form-gen.tsx
+++ b/packages/server/src/actions/form-gen.tsx
@@ -147,6 +147,6 @@ export async function generateGPTFormSchema(args: GeneratorArgsType) {
   try {
     return await customGenerateGPTFormSchema(args, {});
   } catch (e) {
-    throw new Error('Failed to communicate with OpenAI. Please try again.');
+    throw new Error('Failed to communicate with OpenAI.', { cause: e });
   }
 }

--- a/packages/server/tests/form-assistant.test.ts
+++ b/packages/server/tests/form-assistant.test.ts
@@ -193,9 +193,7 @@ describe('Form Assistant', () => {
     await expect(customGenerateGPTFormAutofill(baseAssistantArgs, {})).rejects.toThrow(
       'OpenAI returned an empty response. Please try again.',
     );
-    await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow(
-      'Failed to communicate with OpenAI. Please try again.',
-    );
+    await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
   });
 
   it('should throw an error when OpenAI returns an empty Autofill Fields', async () => {
@@ -209,9 +207,7 @@ describe('Form Assistant', () => {
       await expect(customGenerateGPTFormAutofill(baseAssistantArgs, {})).rejects.toThrow(
         'OpenAI returned an empty Autofill Fields. Please try again.',
       );
-      await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow(
-        'Failed to communicate with OpenAI. Please try again.',
-      );
+      await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
     };
 
     await testEmptyAutofillFields(null);
@@ -227,9 +223,7 @@ describe('Form Assistant', () => {
     await expect(customGenerateGPTFormAutofill(baseAssistantArgs, {})).rejects.toThrow(
       'OpenAI API request exceeded rate limit',
     );
-    await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow(
-      'Failed to communicate with OpenAI. Please try again.',
-    );
+    await expect(generateGPTFormAutofill(baseAssistantArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
   });
 
   it('should return a valid Autofill Fields (multi field)', async () => {

--- a/packages/server/tests/form-gen.test.ts
+++ b/packages/server/tests/form-gen.test.ts
@@ -119,9 +119,7 @@ describe('Form Generation', () => {
     await expect(customGenerateGPTFormSchema(baseGeneratorArgs, {})).rejects.toThrow(
       'OpenAI returned an empty response. Please try again.',
     );
-    await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow(
-      'Failed to communicate with OpenAI. Please try again.',
-    );
+    await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
   });
 
   it('should throw an error when OpenAI returns an empty JSON Schema', async () => {
@@ -136,9 +134,7 @@ describe('Form Generation', () => {
       await expect(customGenerateGPTFormSchema(baseGeneratorArgs, {})).rejects.toThrow(
         'OpenAI returned an empty JSON Schema. Please try again.',
       );
-      await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow(
-        'Failed to communicate with OpenAI. Please try again.',
-      );
+      await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
     };
 
     await testEmptyJSONSchema(null);
@@ -159,9 +155,7 @@ describe('Form Generation', () => {
       await expect(customGenerateGPTFormSchema(baseGeneratorArgs, {})).rejects.toThrow(
         'OpenAI returned an empty UI Schema. Please try again.',
       );
-      await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow(
-        'Failed to communicate with OpenAI. Please try again.',
-      );
+      await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
     };
 
     await testEmptyUISchema(null);
@@ -178,9 +172,7 @@ describe('Form Generation', () => {
     await expect(customGenerateGPTFormSchema(baseGeneratorArgs, {})).rejects.toThrow(
       'OpenAI API request exceeded rate limit',
     );
-    await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow(
-      'Failed to communicate with OpenAI. Please try again.',
-    );
+    await expect(generateGPTFormSchema(baseGeneratorArgs)).rejects.toThrow('Failed to communicate with OpenAI.');
   });
 
   it('should return a valid JSON Schema and UI Schema', async () => {


### PR DESCRIPTION
When rethrowing a new error, add the original error as the cause property so the information is not lost.
Also "Try again" is not applicable to all errors that may happen here - EG: Failing because the gpt-4 model is unavailable for the current tier of the openapi account
